### PR TITLE
25.0.0-ea.23.0.ea format test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           {version: '11', experimental: false},
           {version: '17', experimental: false},
           {version: '24', experimental: false},
-          {version: '25.0.0-ea.23.0.ea', experimental: true}]
+          {version: '25.0.0-ea.25.0.ea', experimental: true}]
         exclude:
           # JDK 8 does not allow toolchains, so testing 'cftests-junit-jdk21' is unnecessary.
           - script: 'cftests-junit-jdk21'


### PR DESCRIPTION
I found that trying '25.0.0-ea.23' revels semvar list on temurin API that has the stashed EA versions, see this failing [test](https://github.com/thisisalexandercook/checker-framework/actions/runs/15593776812/job/43919090627#step:3:16). So it looks like we need to do a major -> minor semvar notation, i.e. '25.0.0-ea.23.0.ea', see this successful [test](https://github.com/thisisalexandercook/checker-framework/actions/runs/15593920679).