### PR TITLE
Lift `isElementAnnotatedForThisCheckerOrUpstreamChecker` to `SourceChecker`

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
 
 /**
  * An abstract {@link SourceChecker} that provides a simple {@link
@@ -313,28 +312,5 @@ public abstract class BaseTypeChecker extends SourceChecker {
                     Arrays.toString(args),
                     causeMessage);
         }
-    }
-
-    /**
-     * The implementation of this method resides in AnnotatedTypeFactory (atf), see {@link
-     * AnnotatedTypeFactory#isElementAnnotatedForThisCheckerOrUpstreamChecker(Element)} We want to
-     * implement it here to avoid duplication and call
-     * atypeFactory.getChecker().isElementAnnotatedForThisCheckerOrUpstreamChecker(elt) in
-     * QualifierDefaults, but implement it here causes type-system error. The reason is the
-     * implementation requires an atf to call {@link AnnotatedTypeFactory#getDeclAnnotation(Element,
-     * Class)}to get the relavent {@code @AnnotatedFor} annotation on the element. However, the
-     * method is called during the initialization of the atf when applying qualifier defaults. At
-     * that time, the atf and the visitor are not fully initialized, so calling getTypeFactory()
-     * will result in a type-system error. The initialization logic is as follows: 1. Create the
-     * checker. 2. Create the visitor, and the visitor's constructor initializes the atf. 3. During
-     * postInit() of the atf, the qualifier defaults are applied, which need to call
-     * isElementAnnotatedForThisCheckerOrUpstreamChecker().
-     *
-     * @param elt the source code element to check, or null
-     * @return true if the element is annotated for this checker or an upstream checker
-     */
-    @Override
-    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
-        return getTypeFactory().isElementAnnotatedForThisCheckerOrUpstreamChecker(elt);
     }
 }

--- a/framework/src/main/java/org/checkerframework/common/util/count/AnnotationStatistics.java
+++ b/framework/src/main/java/org/checkerframework/common/util/count/AnnotationStatistics.java
@@ -23,7 +23,6 @@ import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.source.SourceVisitor;
 import org.checkerframework.framework.source.SupportedOptions;
 import org.checkerframework.javacutil.AnnotationProvider;
-import org.checkerframework.javacutil.BugInCF;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +31,6 @@ import java.util.TreeSet;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.Element;
 import javax.lang.model.element.Name;
 import javax.tools.Diagnostic;
 
@@ -327,10 +325,5 @@ public class AnnotationStatistics extends SourceChecker {
     public AnnotationProvider getAnnotationProvider() {
         throw new UnsupportedOperationException(
                 "getAnnotationProvider is not implemented for this class.");
-    }
-
-    @Override
-    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
-        throw new BugInCF("Unexpected call to determine whether this checker is annotated");
     }
 }

--- a/framework/src/main/java/org/checkerframework/common/util/count/JavaCodeStatistics.java
+++ b/framework/src/main/java/org/checkerframework/common/util/count/JavaCodeStatistics.java
@@ -17,7 +17,6 @@ import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.source.SourceVisitor;
 import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.AnnotationUtils;
-import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.TreeUtils;
 
 import java.util.List;
@@ -25,7 +24,6 @@ import java.util.List;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 
 /**
@@ -204,10 +202,5 @@ public class JavaCodeStatistics extends SourceChecker {
     public AnnotationProvider getAnnotationProvider() {
         throw new UnsupportedOperationException(
                 "getAnnotationProvider is not implemented for this class.");
-    }
-
-    @Override
-    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
-        throw new BugInCF("Unexpected call to determine whether this checker is annotated");
     }
 }

--- a/framework/src/main/java/org/checkerframework/common/util/debug/SignaturePrinter.java
+++ b/framework/src/main/java/org/checkerframework/common/util/debug/SignaturePrinter.java
@@ -15,7 +15,6 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutab
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.javacutil.AbstractTypeProcessor;
 import org.checkerframework.javacutil.AnnotationProvider;
-import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.UserError;
 import org.plumelib.reflection.Signatures;
@@ -100,13 +99,6 @@ public class SignaturePrinter extends AbstractTypeProcessor {
         } else {
             checker =
                     new SourceChecker() {
-
-                        @Override
-                        protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(
-                                Element elt) {
-                            throw new BugInCF(
-                                    "Unexpected call to determine whether this checker is annotated");
-                        }
 
                         @Override
                         protected SourceVisitor<?, ?> createSourceVisitor() {

--- a/framework/src/main/java/org/checkerframework/framework/source/AggregateChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/AggregateChecker.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.lang.model.element.Element;
 import javax.tools.Diagnostic;
 
 /**
@@ -51,5 +52,14 @@ public abstract class AggregateChecker extends SourceChecker {
             // Aggregate checkers do not visit source,
             // the checkers in the aggregate checker do.
         };
+    }
+
+    /**
+     * Always returns false. Whether an aggregate checker is annotated with {@code @AnnotatedFor}
+     * depends on its subcheckers.
+     */
+    @Override
+    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
+        return false;
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/source/AggregateChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/AggregateChecker.java
@@ -56,7 +56,9 @@ public abstract class AggregateChecker extends SourceChecker {
 
     /**
      * Always returns false. Whether an aggregate checker is annotated with {@code @AnnotatedFor}
-     * depends on its subcheckers.
+     * depends on its subcheckers. For checkers that have an upstream checker and want to handle
+     * {@code @AnnotatedFor} in both this and the upstream checker, see {@link
+     * org.checkerframework.checker.initialization.InitializationChecker#getUpstreamCheckerNames()}.
      */
     @Override
     protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {

--- a/framework/src/main/java/org/checkerframework/framework/source/AggregateChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/AggregateChecker.java
@@ -7,7 +7,6 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import javax.lang.model.element.Element;
 import javax.tools.Diagnostic;
 
 /**
@@ -52,16 +51,5 @@ public abstract class AggregateChecker extends SourceChecker {
             // Aggregate checkers do not visit source,
             // the checkers in the aggregate checker do.
         };
-    }
-
-    /**
-     * Always returns false. Whether an aggregate checker is annotated with {@code @AnnotatedFor}
-     * depends on its subcheckers. For checkers that have an upstream checker and want to handle
-     * {@code @AnnotatedFor} in both this and the upstream checker, see {@link
-     * org.checkerframework.checker.initialization.InitializationChecker#getUpstreamCheckerNames()}.
-     */
-    @Override
-    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
-        return false;
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -2997,7 +2997,21 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
      * @param elt the source code element to check, or null
      * @return true if the element is annotated for this checker or an upstream checker
      */
-    protected abstract boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt);
+    private boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
+        AnnotationProvider annotationProvider;
+        try {
+            annotationProvider = getAnnotationProvider();
+        } catch (UnsupportedOperationException e) {
+            throw new BugInCF(e, "Unexpected call to determine whether this checker is annotated");
+        }
+
+        if (annotationProvider instanceof AnnotatedTypeFactory) {
+            return ((AnnotatedTypeFactory) annotationProvider)
+                    .isElementAnnotatedForThisCheckerOrUpstreamChecker(elt);
+        }
+
+        return false;
+    }
 
     /**
      * Returns a modifiable set of lower-case strings that are prefixes for SuppressWarnings

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -2997,7 +2997,11 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
      * @param elt the source code element to check, or null
      * @return true if the element is annotated for this checker or an upstream checker
      */
-    private boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
+    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
+        if (elt == null || (!useConservativeDefaultsSource && !onlyAnnotatedFor)) {
+            return false;
+        }
+
         AnnotationProvider annotationProvider;
         try {
             annotationProvider = getAnnotationProvider();
@@ -3010,7 +3014,9 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
                     .isElementAnnotatedForThisCheckerOrUpstreamChecker(elt);
         }
 
-        return false;
+        throw new BugInCF(
+                "Expected getAnnotationProvider() to return an AnnotatedTypeFactory, but got %s.",
+                annotationProvider.getClass().getName());
     }
 
     /**


### PR DESCRIPTION
This PR lifts the implementation of `isElementAnnotatedForThisCheckerOrUpstreamChecker` into the `SourceChecker`. The advantage of this is the override footprint becomes much smaller, but it may be arguable that the overrides provided more clarity than this implementation. 