### PR TITLE
Move `@AnnotatedFor` check to `BaseTypeChecker`

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
@@ -4,6 +4,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.ClassGetName;
 import org.checkerframework.dataflow.cfg.visualize.CFGVisualizer;
+import org.checkerframework.framework.qual.AnnotatedFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -13,6 +14,7 @@ import org.checkerframework.framework.type.TypeHierarchy;
 import org.checkerframework.javacutil.AbstractTypeProcessor;
 import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.BugInCF;
+import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TypeSystemError;
 import org.checkerframework.javacutil.UserError;
 import org.plumelib.util.CollectionsPlume;
@@ -22,10 +24,13 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.IdentityHashMap;
 import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.PackageElement;
 
 /**
  * An abstract {@link SourceChecker} that provides a simple {@link
@@ -68,6 +73,13 @@ import javax.lang.model.element.Element;
  * @checker_framework.manual #creating-compiler-interface The checker class
  */
 public abstract class BaseTypeChecker extends SourceChecker {
+
+    /**
+     * A mapping from an element to whether it is in an {@code @AnnotatedFor} scope for this checker
+     * or an upstream checker.
+     */
+    private final IdentityHashMap<Element, Boolean> elementAnnotatedForThisCheckerOrUpstreamCache =
+            new IdentityHashMap<>();
 
     /** An array containing just {@code BaseTypeChecker.class}. */
     protected static Class<?>[] baseTypeCheckerClassArray = new Class<?>[] {BaseTypeChecker.class};
@@ -315,26 +327,39 @@ public abstract class BaseTypeChecker extends SourceChecker {
         }
     }
 
-    /**
-     * The implementation of this method resides in AnnotatedTypeFactory (atf), see {@link
-     * AnnotatedTypeFactory#isElementAnnotatedForThisCheckerOrUpstreamChecker(Element)} We want to
-     * implement it here to avoid duplication and call
-     * atypeFactory.getChecker().isElementAnnotatedForThisCheckerOrUpstreamChecker(elt) in
-     * QualifierDefaults, but implement it here causes type-system error. The reason is the
-     * implementation requires an atf to call {@link AnnotatedTypeFactory#getDeclAnnotation(Element,
-     * Class)}to get the relavent {@code @AnnotatedFor} annotation on the element. However, the
-     * method is called during the initialization of the atf when applying qualifier defaults. At
-     * that time, the atf and the visitor are not fully initialized, so calling getTypeFactory()
-     * will result in a type-system error. The initialization logic is as follows: 1. Create the
-     * checker. 2. Create the visitor, and the visitor's constructor initializes the atf. 3. During
-     * postInit() of the atf, the qualifier defaults are applied, which need to call
-     * isElementAnnotatedForThisCheckerOrUpstreamChecker().
-     *
-     * @param elt the source code element to check, or null
-     * @return true if the element is annotated for this checker or an upstream checker
-     */
     @Override
-    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
-        return getTypeFactory().isElementAnnotatedForThisCheckerOrUpstreamChecker(elt);
+    public boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(@Nullable Element elt) {
+        if (elt == null) {
+            throw new BugInCF(
+                    "Call of BaseTypeChecker.isElementAnnotatedForThisCheckerOrUpstreamChecker with null");
+        }
+
+        if (elementAnnotatedForThisCheckerOrUpstreamCache.containsKey(elt)) {
+            return elementAnnotatedForThisCheckerOrUpstreamCache.get(elt);
+        }
+
+        AnnotatedTypeFactory atypeFactory = getTypeFactory();
+        AnnotationMirror annotatedFor = atypeFactory.getDeclAnnotation(elt, AnnotatedFor.class);
+        boolean elementAnnotatedForThisChecker =
+                annotatedFor != null
+                        && atypeFactory.doesAnnotatedForApplyToThisChecker(annotatedFor);
+
+        if (!elementAnnotatedForThisChecker) {
+            Element parent;
+            if (elt.getKind() == ElementKind.PACKAGE) {
+                parent =
+                        ElementUtils.parentPackage(
+                                (PackageElement) elt, atypeFactory.getElementUtils());
+            } else {
+                parent = elt.getEnclosingElement();
+            }
+
+            if (parent != null && isElementAnnotatedForThisCheckerOrUpstreamChecker(parent)) {
+                elementAnnotatedForThisChecker = true;
+            }
+        }
+
+        elementAnnotatedForThisCheckerOrUpstreamCache.put(elt, elementAnnotatedForThisChecker);
+        return elementAnnotatedForThisChecker;
     }
 }

--- a/framework/src/main/java/org/checkerframework/common/util/count/AnnotationStatistics.java
+++ b/framework/src/main/java/org/checkerframework/common/util/count/AnnotationStatistics.java
@@ -330,7 +330,7 @@ public class AnnotationStatistics extends SourceChecker {
     }
 
     @Override
-    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
+    public boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
         throw new BugInCF("Unexpected call to determine whether this checker is annotated");
     }
 }

--- a/framework/src/main/java/org/checkerframework/common/util/count/JavaCodeStatistics.java
+++ b/framework/src/main/java/org/checkerframework/common/util/count/JavaCodeStatistics.java
@@ -207,7 +207,7 @@ public class JavaCodeStatistics extends SourceChecker {
     }
 
     @Override
-    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
+    public boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
         throw new BugInCF("Unexpected call to determine whether this checker is annotated");
     }
 }

--- a/framework/src/main/java/org/checkerframework/common/util/debug/SignaturePrinter.java
+++ b/framework/src/main/java/org/checkerframework/common/util/debug/SignaturePrinter.java
@@ -102,7 +102,7 @@ public class SignaturePrinter extends AbstractTypeProcessor {
                     new SourceChecker() {
 
                         @Override
-                        protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(
+                        public boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(
                                 Element elt) {
                             throw new BugInCF(
                                     "Unexpected call to determine whether this checker is annotated");

--- a/framework/src/main/java/org/checkerframework/framework/source/AggregateChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/AggregateChecker.java
@@ -61,7 +61,7 @@ public abstract class AggregateChecker extends SourceChecker {
      * org.checkerframework.checker.initialization.InitializationChecker#getUpstreamCheckerNames()}.
      */
     @Override
-    protected boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
+    public boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt) {
         return false;
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -2999,7 +2999,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
      * @param elt the source code element to check, or null
      * @return true if the element is annotated for this checker or an upstream checker
      */
-    protected abstract boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt);
+    public abstract boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(Element elt);
 
     /**
      * Returns a modifiable set of lower-case strings that are prefixes for SuppressWarnings

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -536,9 +536,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /** Mapping from a Tree to its TreePath. Shared between all instances. */
     private final TreePathCacher treePathCache;
 
-    /** A mapping of Element &rarr; Whether or not that element is AnnotatedFor this type system. */
-    private final IdentityHashMap<Element, Boolean> elementAnnotatedFors = new IdentityHashMap<>();
-
     /** Whether to ignore type arguments from raw types. */
     public final boolean ignoreRawTypeArguments;
 
@@ -4101,6 +4098,18 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
+     * Returns true if this type factory is currently parsing stub files or ajava files. While this is
+     * true, annotation-file-backed lookup may observe partially loaded annotation-file data.
+     *
+     * @return true if stub files or ajava files are currently being parsed
+     */
+    public boolean isParsingAnnotationFiles() {
+        return stubTypes.isParsing()
+                || ajavaTypes.isParsing()
+                || (currentFileAjavaTypes != null && currentFileAjavaTypes.isParsing());
+    }
+
+    /**
      * Returns all of the declaration annotations whose name equals the passed annotation class (or
      * is an alias for it) including annotations:
      *
@@ -6049,49 +6058,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             }
         }
         return false;
-    }
-
-    /**
-     * Return true if the element has an {@code @AnnotatedFor} annotation, for this checker or an
-     * upstream checker that called this one.
-     *
-     * @param elt the source code element to check, or null
-     * @return true if the element is annotated for this checker or an upstream checker
-     */
-    public boolean isElementAnnotatedForThisCheckerOrUpstreamChecker(@Nullable Element elt) {
-        boolean elementAnnotatedForThisChecker = false;
-
-        if (elt == null) {
-            throw new BugInCF(
-                    "Call of AnnotatedTypeFactory.isElementAnnotatedForThisCheckerOrUpstreamChecker with null");
-        }
-
-        if (elementAnnotatedFors.containsKey(elt)) {
-            return elementAnnotatedFors.get(elt);
-        }
-
-        AnnotationMirror annotatedFor = getDeclAnnotation(elt, AnnotatedFor.class);
-
-        if (annotatedFor != null) {
-            elementAnnotatedForThisChecker = doesAnnotatedForApplyToThisChecker(annotatedFor);
-        }
-
-        if (!elementAnnotatedForThisChecker) {
-            Element parent;
-            if (elt.getKind() == ElementKind.PACKAGE) {
-                parent = ElementUtils.parentPackage((PackageElement) elt, elements);
-            } else {
-                parent = elt.getEnclosingElement();
-            }
-
-            if (parent != null && isElementAnnotatedForThisCheckerOrUpstreamChecker(parent)) {
-                elementAnnotatedForThisChecker = true;
-            }
-        }
-
-        elementAnnotatedFors.put(elt, elementAnnotatedForThisChecker);
-
-        return elementAnnotatedForThisChecker;
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -4098,8 +4098,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Returns true if this type factory is currently parsing stub files or ajava files. While this is
-     * true, annotation-file-backed lookup may observe partially loaded annotation-file data.
+     * Returns true if this type factory is currently parsing stub files or ajava files. While this
+     * is true, annotation-file-backed lookup may observe partially loaded annotation-file data.
      *
      * @return true if stub files or ajava files are currently being parsed
      */

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -748,6 +748,10 @@ public class QualifierDefaults {
             return false;
         }
 
+        if (atypeFactory.isParsingAnnotationFiles()) {
+            return false;
+        }
+
         // TODO: I would expect this:
         //   atypeFactory.isFromByteCode(annotationScope)) {
         // to work instead of the
@@ -761,8 +765,9 @@ public class QualifierDefaults {
                         && !isFromStubFile;
         if (isBytecode) {
             return useConservativeDefaultsBytecode
-                    && !atypeFactory.isElementAnnotatedForThisCheckerOrUpstreamChecker(
-                            annotationScope);
+                    && !atypeFactory
+                            .getChecker()
+                            .isElementAnnotatedForThisCheckerOrUpstreamChecker(annotationScope);
         } else if (isFromStubFile) {
             // TODO: Types in stub files not annotated for a particular checker should be
             // treated as unchecked bytecode.  For now, all types in stub files are treated as
@@ -771,7 +776,9 @@ public class QualifierDefaults {
             // be treated like unchecked code except for methods in the scope of an @AnnotatedFor.
             return false;
         } else if (useConservativeDefaultsSource) {
-            return !atypeFactory.isElementAnnotatedForThisCheckerOrUpstreamChecker(annotationScope);
+            return !atypeFactory
+                    .getChecker()
+                    .isElementAnnotatedForThisCheckerOrUpstreamChecker(annotationScope);
         }
         return false;
     }


### PR DESCRIPTION
This is a follow-up to the `@AnnotatedFor` refactor in #1331. It keeps the shared `@AnnotatedFor` scope computation, but moves ownership of the recursive/cached scope check out of `AnnotatedTypeFactory` and into `BaseTypeChecker`.

This was previously blocked by `QualifierDefaults` calling into `BaseTypeChecker` before normal checker/type-factory initialization was complete, as discussed [here](https://github.com/eisop/checker-framework/pull/1331#discussion_r2320579147).  The concrete failure path comes from stub/ajava parsing during type factory `postInit()`:

```text
GenericAnnotatedTypeFactory.postInit()
  -> parseAnnotationFiles()
  -> stub/ajava parser asks the type factory for a defaulted type
  -> QualifierDefaults.annotate(...)
  -> QualifierDefaults.applyConservativeDefaults(...)
  -> checker.isElementAnnotatedForThisCheckerOrUpstreamChecker(...)
  -> BaseTypeChecker.getTypeFactory()
```

At that point, routing through the checker can cause an NPE because `getTypeFactory()` depends on the visitor, which is not available yet.

This PR avoids that by skipping conservative unchecked-code `@AnnotatedFor` lookup while stub/ajava parsing is active. This does not change the existing policy for stub-file elements: `QualifierDefaults` currently treats stub files as checked code, see comment [here](https://github.com/eisop/checker-framework/blob/d9e5dd41b33f58b9a531ebc26ac645ffe0b51965/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java#L810). That existing block handles elements after they are known to come from parsed stub files. The new guard handles the earlier phase where annotation-file metadata is still being parsed.

Most stubs, including annotated-JDK class stubs, are only indexed during initialization and parsed lazily later, when an annotation lookup reaches that JDK class. The risky cases are the annotation files parsed eagerly during `postInit()`, such as checker `@StubFiles`, command-line stubs, ajava files, and annotated-JDK `package-info.java` files.