### PR TITLE
Add test for annotated anonymous class creation bounds

### DIFF
--- a/framework/tests/viewpointtest/AnonymousClassBounds.java
+++ b/framework/tests/viewpointtest/AnonymousClassBounds.java
@@ -1,0 +1,33 @@
+import viewpointtest.quals.*;
+
+/**
+ * Tests that a type-use annotation written on an anonymous class creation expression is validated
+ * against the declaration bound of the class being extended.
+ *
+ * <p>In Java 11 and lower, javac attaches that annotation to the anonymous class declaration's
+ * modifiers rather than to its extends clause, so this check must not depend on the extends clause
+ * carrying the annotation.
+ */
+public class AnonymousClassBounds {
+    @SuppressWarnings({"inconsistent.constructor.type", "super.invocation.invalid"})
+    @A static class AClass {}
+
+    void test() {
+        // @A is AClass's declaration bound, so this use is valid.
+        new @A AClass() {};
+
+        // @B is a sibling of @A, so it is outside AClass's declaration bound.
+        // :: warning: (cast.unsafe.constructor.invocation)
+        // :: error: (type.invalid.annotations.on.use)
+        new @B AClass() {};
+
+        // @Bottom is below the declaration bound, so this use is valid.
+        // :: warning: (cast.unsafe.constructor.invocation)
+        new @Bottom AClass() {};
+
+        // @Top is above the declaration bound.
+        // :: error: (new.class.type.invalid)
+        // :: error: (type.invalid.annotations.on.use)
+        new @Top AClass() {};
+    }
+}


### PR DESCRIPTION
**This PR is expected to fail CI on JDK 11.** That failure is the point: it demonstrates a JDK-version-dependent gap before the fix is proposed separately.

A type-use annotation written on an anonymous class creation expression:

```java
new @Anno Class() {}
```

should be validated against the declaration bound of the class being extended, as it already is for a non-anonymous creation.

On JDK 17 and later this works. On JDK 11, javac attaches the annotation to the anonymous class declaration's modifiers rather than to its extends clause, so the extends clause is a bare `IdentifierTree`. `BaseTypeValidator.shouldCheckTopLevelDeclaredOrPrimitiveType` skips the top-level check for such a tree (`TreeUtils.typeTreeKinds()` contains `ANNOTATED_TYPE` but not `IDENTIFIER`), so the conflict is never checked.

Verified locally against this branch's base with `checker/bin/javac`:

| JDK | diagnostics on the new file |
| --- | --- |
| 11 | 3 — both `type.invalid.annotations.on.use` errors **missing** |
| 21 | 5 — as expected by the test |

Expected CI result:

| job | expected |
| --- | --- |
| JDK 11 | fails: `ViewpointTestCheckerTest`, 2 expected diagnostics not found (lines 22 and 31) |
| JDK 17 / 21 / later | passes |

The test lives in the framework's own viewpoint test checker, so it guards every checker on the JDK matrix rather than relying on a downstream checker to notice. A fix is prepared and will follow in a separate PR, after which this test passes on all JDKs.